### PR TITLE
clear function add_delay_jitter / remove option valid check 

### DIFF
--- a/lib/msf/core/auxiliary/scanner.rb
+++ b/lib/msf/core/auxiliary/scanner.rb
@@ -299,11 +299,8 @@ def scanner_show_progress
   end
 end
 
-def add_delay_jitter(_delay, _jitter)
+def add_delay_jitter(delay, jitter)
   # Introduce the delay
-  delay_value = _delay.to_i
-  original_value = delay_value
-  jitter_value = _jitter.to_i
 
   # Retrieve the jitter value and delay value
   # Delay = number of milliseconds to wait between each request
@@ -311,24 +308,13 @@ def add_delay_jitter(_delay, _jitter)
   # Delay is 1000ms (i.e. 1 second), Jitter is 50.
   # 50/100 = 0.5; 0.5*1000 = 500. Therefore, the per-request
   # delay will be 1000 +/- a maximum of 500ms.
-  if delay_value > 0
-    if jitter_value > 0
-       rnd = Random.new
-       if (rnd.rand(2) == 0)
-          delay_value += rnd.rand(jitter_value)
-       else
-          delay_value -= rnd.rand(jitter_value)
-       end
-       if delay_value < 0
-          delay_value = 0
-       end
-    end
-    final_delay = delay_value.to_f / 1000.0
-    vprint_status("Delaying for #{final_delay} second(s) (#{original_value}ms +/- #{jitter_value}ms)")
-    sleep final_delay
-  end
+  return unless delay > 0  # no delay need
+  rand_jitter = jitter > 0 ? Random.rand(jitter) : 0
+  rand_delay = Random.rand(2) == 0 ? delay + rand_jitter : delay - rand_jitter
+  rand_delay = rand_delay > 0 ? (rand_delay.to_f / 1000.0) : 0
+  vprint_status("Delaying for #{rand_delay} second(s) (#{delay}ms +/- #{jitter}ms)")
+  sleep rand_delay
 end
 
 end
 end
-

--- a/modules/auxiliary/scanner/portscan/ack.rb
+++ b/modules/auxiliary/scanner/portscan/ack.rb
@@ -67,7 +67,7 @@ class Metasploit3 < Msf::Auxiliary
         pcap.setfilter(getfilter(shost, sport, dhost, dport))
 
         # Add the delay based on JITTER and DELAY if needs be
-        add_delay_jitter(delay_value,jitter_value)
+        add_delay_jitter(delay_value, jitter_value)
 
         begin
           probe = buildprobe(shost, sport, dhost, dport)

--- a/modules/auxiliary/scanner/portscan/ack.rb
+++ b/modules/auxiliary/scanner/portscan/ack.rb
@@ -67,7 +67,7 @@ class Metasploit3 < Msf::Auxiliary
         pcap.setfilter(getfilter(shost, sport, dhost, dport))
 
         # Add the delay based on JITTER and DELAY if needs be
-        add_delay_jitter(delay_value, jitter_value)
+        add_delay_jitter(datastore['DELAY'], datastore['JITTER'])
 
         begin
           probe = buildprobe(shost, sport, dhost, dport)

--- a/modules/auxiliary/scanner/portscan/ack.rb
+++ b/modules/auxiliary/scanner/portscan/ack.rb
@@ -45,25 +45,15 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def run_batch(hosts)
-
-    ports = Rex::Socket.portspec_crack(datastore['PORTS'])
-    if ports.empty?
-      raise Msf::OptionValidateError.new(['PORTS'])
-    end
-
-    jitter_value = datastore['JITTER'].to_i
-    if jitter_value < 0
-      raise Msf::OptionValidateError.new(['JITTER'])
-    end
-
-    delay_value = datastore['DELAY'].to_i
-    if delay_value < 0
-      raise Msf::OptionValidateError.new(['DELAY'])
-    end
-
     open_pcap
 
     pcap = self.capture
+
+    ports = Rex::Socket.portspec_crack(datastore['PORTS'])
+
+    if ports.empty?
+      raise Msf::OptionValidateError.new(['PORTS'])
+    end
 
     to = (datastore['TIMEOUT'] || 500).to_f / 1000.0
 

--- a/modules/auxiliary/scanner/portscan/ftpbounce.rb
+++ b/modules/auxiliary/scanner/portscan/ftpbounce.rb
@@ -49,18 +49,9 @@ class Metasploit3 < Msf::Auxiliary
 
   def run_host(ip)
     ports = Rex::Socket.portspec_crack(datastore['PORTS'])
+
     if ports.empty?
       raise Msf::OptionValidateError.new(['PORTS'])
-    end
-
-    jitter_value = datastore['JITTER'].to_i
-    if jitter_value < 0
-      raise Msf::OptionValidateError.new(['JITTER'])
-    end
-
-    delay_value = datastore['DELAY'].to_i
-    if delay_value < 0
-      raise Msf::OptionValidateError.new(['DELAY'])
     end
 
     return if not connect_login

--- a/modules/auxiliary/scanner/portscan/ftpbounce.rb
+++ b/modules/auxiliary/scanner/portscan/ftpbounce.rb
@@ -68,7 +68,7 @@ class Metasploit3 < Msf::Auxiliary
       begin
 
         # Add the delay based on JITTER and DELAY if needs be
-        add_delay_jitter(delay_value,jitter_value)
+        add_delay_jitter(delay_value, jitter_value)
 
         host = (ip.split('.') + [port / 256, port % 256]).join(',')
         resp = send_cmd(["PORT", host])

--- a/modules/auxiliary/scanner/portscan/ftpbounce.rb
+++ b/modules/auxiliary/scanner/portscan/ftpbounce.rb
@@ -68,7 +68,7 @@ class Metasploit3 < Msf::Auxiliary
       begin
 
         # Add the delay based on JITTER and DELAY if needs be
-        add_delay_jitter(delay_value, jitter_value)
+        add_delay_jitter(datastore['DELAY'], datastore['JITTER'])
 
         host = (ip.split('.') + [port / 256, port % 256]).join(',')
         resp = send_cmd(["PORT", host])

--- a/modules/auxiliary/scanner/portscan/syn.rb
+++ b/modules/auxiliary/scanner/portscan/syn.rb
@@ -65,7 +65,7 @@ class Metasploit3 < Msf::Auxiliary
         self.capture.setfilter(getfilter(shost, sport, dhost, dport))
 
         # Add the delay based on JITTER and DELAY if needs be
-        add_delay_jitter(delay_value, jitter_value)
+        add_delay_jitter(datastore['DELAY'], datastore['JITTER'])
 
         begin
           probe = buildprobe(shost, sport, dhost, dport)

--- a/modules/auxiliary/scanner/portscan/syn.rb
+++ b/modules/auxiliary/scanner/portscan/syn.rb
@@ -43,23 +43,15 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def run_batch(hosts)
+    open_pcap
+
+    pcap = self.capture
+
     ports = Rex::Socket.portspec_crack(datastore['PORTS'])
+
     if ports.empty?
       raise Msf::OptionValidateError.new(['PORTS'])
     end
-
-    jitter_value = datastore['JITTER'].to_i
-    if jitter_value < 0
-      raise Msf::OptionValidateError.new(['JITTER'])
-    end
-
-    delay_value = datastore['DELAY'].to_i
-    if delay_value < 0
-      raise Msf::OptionValidateError.new(['DELAY'])
-    end
-
-    open_pcap
-    pcap = self.capture
 
     to = (datastore['TIMEOUT'] || 500).to_f / 1000.0
 

--- a/modules/auxiliary/scanner/portscan/syn.rb
+++ b/modules/auxiliary/scanner/portscan/syn.rb
@@ -65,7 +65,7 @@ class Metasploit3 < Msf::Auxiliary
         self.capture.setfilter(getfilter(shost, sport, dhost, dport))
 
         # Add the delay based on JITTER and DELAY if needs be
-        add_delay_jitter(delay_value,jitter_value)
+        add_delay_jitter(delay_value, jitter_value)
 
         begin
           probe = buildprobe(shost, sport, dhost, dport)

--- a/modules/auxiliary/scanner/portscan/tcp.rb
+++ b/modules/auxiliary/scanner/portscan/tcp.rb
@@ -60,7 +60,7 @@ class Metasploit3 < Msf::Auxiliary
           begin
 
             # Add the delay based on JITTER and DELAY if needs be
-            add_delay_jitter(delay_value, jitter_value)
+            add_delay_jitter(datastore['DELAY'], datastore['JITTER'])
 
             # Actually perform the TCP connection
             s = connect(false,

--- a/modules/auxiliary/scanner/portscan/tcp.rb
+++ b/modules/auxiliary/scanner/portscan/tcp.rb
@@ -49,16 +49,6 @@ class Metasploit3 < Msf::Auxiliary
       raise Msf::OptionValidateError.new(['PORTS'])
     end
 
-    jitter_value = datastore['JITTER'].to_i
-    if jitter_value < 0
-      raise Msf::OptionValidateError.new(['JITTER'])
-    end
-
-    delay_value = datastore['DELAY'].to_i
-    if delay_value < 0
-      raise Msf::OptionValidateError.new(['DELAY'])
-    end
-
     while(ports.length > 0)
       t = []
       r = []

--- a/modules/auxiliary/scanner/portscan/tcp.rb
+++ b/modules/auxiliary/scanner/portscan/tcp.rb
@@ -22,7 +22,6 @@ class Metasploit3 < Msf::Auxiliary
         This does not need administrative privileges on the source machine, which
         may be useful if pivoting.
       },
-      'Description' => 'Enumerate open TCP services',
       'Author'      => [ 'hdm', 'kris katterjohn' ],
       'License'     => MSF_LICENSE
     )

--- a/modules/auxiliary/scanner/portscan/tcp.rb
+++ b/modules/auxiliary/scanner/portscan/tcp.rb
@@ -60,7 +60,7 @@ class Metasploit3 < Msf::Auxiliary
           begin
 
             # Add the delay based on JITTER and DELAY if needs be
-            add_delay_jitter(delay_value,jitter_value)
+            add_delay_jitter(delay_value, jitter_value)
 
             # Actually perform the TCP connection
             s = connect(false,

--- a/modules/auxiliary/scanner/portscan/xmas.rb
+++ b/modules/auxiliary/scanner/portscan/xmas.rb
@@ -70,7 +70,7 @@ class Metasploit3 < Msf::Auxiliary
           probe = buildprobe(shost, sport, dhost, dport)
 
           # Add the delay based on JITTER and DELAY if needs be
-          add_delay_jitter(delay_value,jitter_value)
+          add_delay_jitter(delay_value, jitter_value)
 
           unless capture_sendto(probe, dhost)
             host_queue.delete(dhost)

--- a/modules/auxiliary/scanner/portscan/xmas.rb
+++ b/modules/auxiliary/scanner/portscan/xmas.rb
@@ -70,7 +70,7 @@ class Metasploit3 < Msf::Auxiliary
           probe = buildprobe(shost, sport, dhost, dport)
 
           # Add the delay based on JITTER and DELAY if needs be
-          add_delay_jitter(delay_value, jitter_value)
+          add_delay_jitter(datastore['DELAY'], datastore['JITTER'])
 
           unless capture_sendto(probe, dhost)
             host_queue.delete(dhost)

--- a/modules/auxiliary/scanner/portscan/xmas.rb
+++ b/modules/auxiliary/scanner/portscan/xmas.rb
@@ -50,18 +50,9 @@ class Metasploit3 < Msf::Auxiliary
     pcap = self.capture
 
     ports = Rex::Socket.portspec_crack(datastore['PORTS'])
+
     if ports.empty?
       raise Msf::OptionValidateError.new(['PORTS'])
-    end
-
-    jitter_value = datastore['JITTER'].to_i
-    if jitter_value < 0
-      raise Msf::OptionValidateError.new(['JITTER'])
-    end
-
-    delay_value = datastore['DELAY'].to_i
-    if delay_value < 0
-      raise Msf::OptionValidateError.new(['DELAY'])
     end
 
     to = (datastore['TIMEOUT'] || 500).to_f / 1000.0


### PR DESCRIPTION
- clear function **`add_delay_jitter`**
- remove option valid check
## Verification

List the steps needed to make sure this thing works
- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/portscan/ack`
- [ ] `use auxiliary/scanner/portscan/ftpbounce`
- [ ] `use auxiliary/scanner/portscan/syn`
- [ ] `use auxiliary/scanner/portscan/tcp`
- [ ] `use auxiliary/scanner/portscan/xmas`
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not

```
msf auxiliary(tcp) > show options 

Module options (auxiliary/scanner/portscan/tcp):

   Name         Current Setting  Required  Description
   ----         ---------------  --------  -----------
   CONCURRENCY  10               yes       The number of concurrent ports to check per host
   DELAY        0                yes       The delay between connections, per thread, in milliseconds
   JITTER       0                yes       The delay jitter factor (maximum value by which to +/- DELAY) in milliseconds.
   PORTS        1-10000          yes       Ports to scan (e.g. 22-25,80,110-900)
   RHOSTS                        yes       The target address range or CIDR identifier
   THREADS      1                yes       The number of concurrent threads
   TIMEOUT      1000             yes       The socket connect timeout in milliseconds

msf auxiliary(tcp) > set RHOSTS 192.168.1.1
RHOSTS => 192.168.1.1
msf auxiliary(tcp) > set PORTS 80
PORTS => 80
msf auxiliary(tcp) > set VERBOSE true
VERBOSE => true
msf auxiliary(tcp) > set DELAY 1000
DELAY => 1000
msf auxiliary(tcp) > set JITTER 500
JITTER => 500
msf auxiliary(tcp) > run 

[*] Delaying for 1.285 second(s) (1000ms +/- 500ms)
[*] 192.168.1.1:80 - TCP OPEN
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
